### PR TITLE
Day three (#12)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "ufosurv",
+  "compatibility_date": "2026-05-10",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  },
+  "observability": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
* rebase from main (#11)

* add spawn telegraph indicator (red bar)

Pre-rolls the next enemy's direction + entry coords one cadence-window ahead so a red warning bar can be drawn on the wall it'll come through.

Visual: pure-red sigmoidal gradient peaking at the edge, falling off into the field. Two phases over the spawn countdown:
- telegraph (first 67%): full edge length, gentle sigmoid, alpha 0.25→0.4
- focus (last 33%): bar shrinks to ~10% of edge and localizes to the spawn point, sigmoid sharpens to near-step, alpha ramps to 1.0

Z-order: bg → indicator → sprites (player flies over) → HUD. drawSprites() in drawGameplay replaced with manual ordered drawSprite calls so the indicator stays under sprites and isn't clobbered by bg redraw.

New shim API: rect(x,y,w,h) and fillLinearGradient(x0,y0,x1,y1,stops) in src/gamelab/renderer.ts.

R-restart now also clears nextSpawn so the post-restart first enemy gets a fresh telegraph cycle.



* indicator: span the full edge instead of centering on spawn point

The previous version centered the bar on (tx, ty) with a halfLen extent on each side and clamped to [0, FIELD]. Near-corner spawn targets caused the bar to appear shifted toward the spawn point even during the telegraph phase when lengthFraction was 1.0 — a 200px halfLen on a target at y=50 clamped to the [0, 250] range, only ~63% of the edge.

Fix: drop the per-side length math entirely. The bar always spans the full edge along the parallel axis. Focus phase still sharpens the perpendicular sigmoid and ramps peak alpha toward 1.0, but no longer shrinks along the edge. The exact spawn point is now telegraphed only by the enemy emerging from that edge once the countdown completes.

Removes FOCUS_LENGTH_FLOOR constant, lengthFraction return field, and the tx/ty destructure in drawSpawnIndicator (only direction is needed now).



* indicator: spawn-centered bar with overhang for full-edge coverage

Previous attempt removed the focus-phase shrink to dodge the corner-spawn clipping problem. That broke the intended behavior — the shrink toward the spawn point is the whole point of the cue.

This version restores spawn-centering and keeps the shrink, but uses halfLen = FIELD * lengthFraction. At telegraph (lengthFraction = 1.0) that's halfLen = 400, so the rect extends a full FIELD on either side of the spawn coord — guaranteed to cover [0, FIELD] visibly even with a corner spawn (ty = 10 or 390). Canvas2D clips the overhang at the canvas boundary; the player only ever sees a full edge during the telegraph.

In focus phase halfLen shrinks via the existing ease-in down to FIELD * 0.05 = 20 px — bar narrows to ~40 px wide centered on the entry point (~2× the rendered enemy hitbox). Drops the per-corner clamping math entirely; the canvas's own clipping does that job correctly.

Tunable: FOCUS_LENGTH_FLOOR (was 0.1, now 0.05) controls the focus-end width.



* indicator: replace bar with shrinking radial Gaussian (#7)

Per Hyrum's request: drop the edge-spanning bar entirely. The marker is now a 2D radial Gaussian anchored at the wall coordinate nearest the spawn point — the half outside the canvas is naturally clipped, so the visible portion is bright at the wall and fades into the field along the direction of travel.

Single-curve timing replaces the telegraph/focus phase split: σ shrinks ease-in (t²) from 25 (2σ ≈ 50 px to match the spec) down to 2 (near- point collapse). Peak alpha simultaneously ramps 0.5 → 1.0 to keep the marker perceptible as area shrinks ~150×.

New shim API: fillRadialGradient(cx, cy, radius, stops) in renderer.ts. fillLinearGradient + rect-with-bar-geometry no longer used by the indicator but stay exported (cheap, may be useful for future cues).

Tunables at top of game.ts: SIGMA_INITIAL, SIGMA_FINAL, ALPHA_PEAK_*, GAUSSIAN_RADIUS_SIGMAS.



* Update vite.config.ts (#9)

Interface with cloudflare

---------



* Create wrangler.jsonc

---------