### PR TITLE
rework online co-op to deterministic shared-seed netcode (no P2 input…

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To run the workflow manually (e.g., to redeploy without a code change): Actions 
 
 On the title screen press **O** (or click "host online co-op") to host a game. You'll get a room code and a shareable link — send the link to a friend. When they open it, they join as player 2 over a direct **peer-to-peer WebRTC** connection. Both players use the arrow keys on their own machine.
 
-The netcode is **host-authoritative**: player 1 runs the single authoritative simulation and broadcasts a state snapshot every tick; player 2 sends only its input and renders what it's told. If the host leaves, the session ends.
+The netcode is **deterministic**: both players run the same simulation. Enemies are generated locally from a shared seed (so they never travel over the wire), and each player flies their own ship from local input — so **neither player has input lag**. Only each player's position and a few host-decided events that depend on both ships (coin pickups, damage, restarts) cross the wire. Player 1 is the authority for those shared events; if it leaves, the session ends.
 
 Connections are brokered by a Cloudflare Worker + Durable Object (`worker/`) that does WebRTC signaling only — once the peers are connected, gameplay traffic never touches the server. The signaling backend lives at the **same origin** as the game, so online co-op requires the app to be served from the Worker (`npm run cf:deploy`, or `npm run cf:dev` locally) rather than from GitHub Pages. ICE uses public STUN with no TURN, so a pair behind two symmetric NATs may fail to connect.
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -27,22 +27,19 @@ import {
   rect,
   rgb,
   type Sprite,
+  setRandomSeed,
   TOP,
   text,
   textAlign,
   textSize,
 } from './gamelab';
 import {
-  type BlockSnap,
-  type GuestSession,
-  type HostSession,
   hostSession,
   joinSession,
   makeRoomCode,
-  type Phase,
-  type PlayerInput,
+  type NetMessage,
   roomFromUrl,
-  type Snapshot,
+  type Session,
   shareLink,
 } from './net';
 
@@ -64,27 +61,30 @@ let winCon = 25;
 // unused in the original; restart and damage logic check `players > 2`.
 let players = 1;
 
-// --- Online co-op (host-authoritative; transport in src/net) ----------------
-// netRole selects how draw() behaves: 'local' is the original same-keyboard
-// game; 'host' runs the one authoritative simulation and broadcasts snapshots;
-// 'guest' renders received snapshots and sends only its own input upstream.
+// --- Online co-op (deterministic; transport in src/net) ---------------------
+// netRole selects how draw() behaves. 'local' is the original same-keyboard
+// game. Online, BOTH clients run the same simulation: enemies come from a
+// shared seed, each player runs their OWN ship from local input (zero lag),
+// and only positions + a few host-authoritative events cross the wire.
 type NetRole = 'local' | 'host' | 'guest';
 type NetStatus = 'idle' | 'waiting' | 'connecting' | 'connected' | 'disconnected';
 let netRole: NetRole = 'local';
 let netStatus: NetStatus = 'idle';
 let roomCode = '';
-let host: HostSession | null = null;
-let guest: GuestSession | null = null;
-// Host side: the guest's latest held controls, plus its previous `up` so the
-// host can derive a jump edge from held state (robust to dropped packets).
-let latestRemoteInput: PlayerInput = { up: false, left: false, right: false };
-let prevRemoteUp = false;
-// Guest side: the latest authoritative frame + a local block render pool.
-let latestSnapshot: Snapshot | null = null;
-let guestBlocks: Sprite[] = [];
-// Host side: each enemy block's animation index, so a snapshot can tell the
-// guest which sprite to draw. WeakMap so destroyed blocks drop out for free.
-const blockAnimIndex = new WeakMap<Sprite, number>();
+let session: Session | null = null;
+// The other player's most recent ship position (host sees the guest's, guest
+// sees the host's). Applied directly so the host's collision checks use the
+// real position, not a smoothed one.
+let remoteX = 200;
+let remoteY = 200;
+// Host: whether the current match's `start` has been sent. Guest: whether a
+// `start` has been received (gates the gameplay screen vs the waiting screen).
+let onlineMatchStarted = false;
+let gameStarted = false;
+// Host-only: suppresses repeat damage from a networked off-field ship for a few
+// ticks (the host can't force the remote ship back on-field; the guest's own
+// respawn position only arrives ~½ RTT later).
+let damageCooldown = 0;
 
 const shipAnimations: string[] = [];
 for (let i = 1; i <= 21; i++) {
@@ -155,26 +155,19 @@ export function init(): void {
 }
 
 export function draw(): void {
-  // Guest renders whatever the host last sent; it never simulates.
+  if (netRole === 'host') {
+    drawHost();
+    return;
+  }
   if (netRole === 'guest') {
     drawGuest();
     return;
   }
-  // Host shows the lobby until a guest connects, then falls through to the
-  // normal local flow below and additionally broadcasts a snapshot each tick.
-  if (netRole === 'host' && netStatus !== 'connected') {
-    drawHostLobby();
-    return;
-  }
-
+  // Local same-keyboard play.
   if (health > 0 && points < winCon && difficulty > 0) {
     drawGameplay();
   } else {
     drawNonGameplay();
-  }
-
-  if (netRole === 'host') {
-    host?.sendSnapshot(buildSnapshot());
   }
 }
 
@@ -188,26 +181,15 @@ function drawGameplay(): void {
   UFO1.setAnimation('ufo_1');
   UFO2.setAnimation('ufo_2');
 
-  // UFO1 is always this machine's arrow keys.
   if (keyWentDown('up')) UFO1.velocityY = -12;
+  if (keyWentDown('w')) UFO2.velocityY = -12;
+
   UFO1.velocityX = 0;
+  UFO2.velocityX = 0;
   if (keyDown('left')) UFO1.velocityX = -5;
   if (keyDown('right')) UFO1.velocityX = 5;
-
-  // UFO2 is player two: WASD on the same keyboard locally, or the guest's
-  // networked input when hosting (jump edge derived from the held `up`).
-  UFO2.velocityX = 0;
-  if (netRole === 'host') {
-    const remote = latestRemoteInput;
-    if (remote.up && !prevRemoteUp) UFO2.velocityY = -12;
-    prevRemoteUp = remote.up;
-    if (remote.left) UFO2.velocityX = -5;
-    if (remote.right) UFO2.velocityX = 5;
-  } else {
-    if (keyWentDown('w')) UFO2.velocityY = -12;
-    if (keyDown('a')) UFO2.velocityX = -5;
-    if (keyDown('d')) UFO2.velocityX = 5;
-  }
+  if (keyDown('a')) UFO2.velocityX = -5;
+  if (keyDown('d')) UFO2.velocityX = 5;
 
   UFO2.velocityY += 1.5;
   UFO1.velocityY += 1.5;
@@ -321,8 +303,6 @@ function spawnBlock(): void {
   const randomIndex = randomNumber(0, shipAnimations.length - 1);
   const name = shipAnimations[randomIndex];
   if (name) newBlock.setAnimation(name);
-  // Remember which sprite this is so host snapshots can name it for the guest.
-  blockAnimIndex.set(newBlock, randomIndex);
   blocks.push(newBlock);
 
   decideNextSpawn();
@@ -639,10 +619,9 @@ function startHosting(): void {
   roomCode = makeRoomCode();
   players = 3; // two ships active
   difficulty = -1; // once a guest connects, the host lands on difficulty select
-  host = hostSession(roomCode, {
-    onPeerInput: (input) => {
-      latestRemoteInput = input;
-    },
+  onlineMatchStarted = false;
+  session = hostSession(roomCode, {
+    onMessage: onNetMessage,
     onConnected: () => {
       netStatus = 'connected';
     },
@@ -657,13 +636,11 @@ function startJoining(code: string): void {
   netStatus = 'connecting';
   roomCode = code;
   players = 3;
-  guest = joinSession(code, {
-    onSnapshot: (snap) => {
-      latestSnapshot = snap;
-      if (netStatus !== 'connected') netStatus = 'connected';
-    },
+  gameStarted = false;
+  session = joinSession(code, {
+    onMessage: onNetMessage,
     onConnected: () => {
-      netStatus = 'connected';
+      if (netStatus === 'connecting') netStatus = 'connected';
     },
     onDisconnected: () => {
       netStatus = 'disconnected';
@@ -672,18 +649,14 @@ function startJoining(code: string): void {
 }
 
 function resetToLocalTitle(): void {
-  host?.close();
-  guest?.close();
-  host = null;
-  guest = null;
+  session?.close();
+  session = null;
   netRole = 'local';
   netStatus = 'idle';
   roomCode = '';
-  latestSnapshot = null;
-  latestRemoteInput = { up: false, left: false, right: false };
-  prevRemoteUp = false;
-  for (const b of guestBlocks) b.destroy();
-  guestBlocks = [];
+  onlineMatchStarted = false;
+  gameStarted = false;
+  damageCooldown = 0;
   for (const b of blocks) b.destroy();
   blocks = [];
   players = 1;
@@ -694,33 +667,260 @@ function resetToLocalTitle(): void {
   coinExists = false;
   nextSpawn = null;
   difficulty = -2;
+  setRandomSeed(null); // restore non-deterministic local play
 }
 
-function hostPhase(): Phase {
-  if (health === 0) return 'over';
-  if (points >= winCon) return 'win';
-  if (difficulty > 0) return 'play';
-  return 'wait';
+// The local player's ship: UFO1 when hosting, UFO2 when guest.
+function ownShip(): Sprite {
+  return netRole === 'host' ? UFO1 : UFO2;
 }
 
-function buildSnapshot(): Snapshot {
-  const snapBlocks: BlockSnap[] = [];
-  for (const b of blocks) {
-    snapBlocks.push({ x: Math.round(b.x), y: Math.round(b.y), anim: blockAnimIndex.get(b) ?? 0 });
+function respawnOwnShip(): void {
+  const s = ownShip();
+  s.x = 200;
+  s.y = 200;
+  s.velocityX = 0;
+  s.velocityY = -15;
+}
+
+function offField(s: Sprite): boolean {
+  return s.x < 0 || s.x > 400 || s.y < 0 || s.y > 400;
+}
+
+// Coins are host-authoritative (who grabs one depends on both ships), so the
+// host picks positions from Math.random — NOT the seeded RNG — to keep the
+// shared enemy stream byte-identical on both clients.
+function placeCoin(): void {
+  coin.x = Math.round(50 + Math.random() * 300);
+  coin.y = Math.round(50 + Math.random() * 300);
+  coinExists = true;
+}
+
+// Applies every host→guest event on the guest, plus the per-tick `pos` (which
+// both sides receive). The host only ever receives `pos`.
+function onNetMessage(msg: NetMessage): void {
+  switch (msg.t) {
+    case 'pos':
+      remoteX = msg.x;
+      remoteY = msg.y;
+      break;
+    case 'start':
+      setRandomSeed(msg.seed);
+      difficulty = msg.difficulty;
+      health = msg.health;
+      points = msg.points;
+      winCon = msg.winCon;
+      count = 0;
+      nextSpawn = null;
+      damageCooldown = 0;
+      for (const b of blocks) b.destroy();
+      blocks = [];
+      coin.x = msg.coinX;
+      coin.y = msg.coinY;
+      coinExists = true;
+      gameStarted = true;
+      break;
+    case 'coin':
+      points = msg.points;
+      coin.x = msg.x;
+      coin.y = msg.y;
+      coinExists = true;
+      break;
+    case 'damage':
+      health = msg.health;
+      for (const b of blocks) b.destroy();
+      blocks = [];
+      respawnOwnShip();
+      break;
+    case 'wait':
+      gameStarted = false;
+      break;
   }
-  return {
-    phase: hostPhase(),
-    ufo1: { x: Math.round(UFO1.x), y: Math.round(UFO1.y) },
-    ufo2: { x: Math.round(UFO2.x), y: Math.round(UFO2.y) },
-    coin: { x: Math.round(coin.x), y: Math.round(coin.y), shown: coinExists },
-    blocks: snapBlocks,
+}
+
+// Host: seed and broadcast a (re)start. `fresh` resets score/health for a new
+// match; a win-continue keeps them and just reseeds the enemy wave.
+function startMatchHost(fresh: boolean): void {
+  if (fresh) {
+    health = 10;
+    points = 0;
+    winCon = 25;
+  }
+  const seed = Math.floor(Math.random() * 0x7fffffff);
+  setRandomSeed(seed);
+  count = 0;
+  nextSpawn = null;
+  damageCooldown = 0;
+  for (const b of blocks) b.destroy();
+  blocks = [];
+  placeCoin();
+  onlineMatchStarted = true;
+  session?.send({
+    t: 'start',
+    seed,
+    difficulty,
     health,
     points,
     winCon,
-    difficulty,
-    count,
-    spawn: nextSpawn ? { dir: nextSpawn.direction, x: nextSpawn.x, y: nextSpawn.y } : null,
-  };
+    coinX: Math.round(coin.x),
+    coinY: Math.round(coin.y),
+  });
+}
+
+function drawHost(): void {
+  if (netStatus !== 'connected') {
+    drawHostLobby();
+    return;
+  }
+  const playing = health > 0 && points < winCon && difficulty > 0;
+  if (playing) {
+    if (!onlineMatchStarted) startMatchHost(true);
+    drawGameplayOnline();
+    return;
+  }
+  // Leaving gameplay (to select, or on game over) clears the match flag so the
+  // next entry seeds a fresh world; a win keeps it (the continue reseeds).
+  if (difficulty <= 0 || health === 0) onlineMatchStarted = false;
+  drawOnlineMenus();
+}
+
+// The shared online gameplay tick, run by BOTH clients. The local ship is
+// driven by local input; the remote ship sits at its last received position;
+// enemies advance deterministically from the shared seed. Only the host decides
+// coin/damage events.
+function drawGameplayOnline(): void {
+  const isHost = netRole === 'host';
+  const localShip = isHost ? UFO1 : UFO2;
+  const remoteShip = isHost ? UFO2 : UFO1;
+
+  if (!nextSpawn) decideNextSpawn();
+
+  backGround.setAnimation('space_1');
+  UFO1.setAnimation('ufo_1');
+  UFO2.setAnimation('ufo_2');
+  coin.setAnimation('coin');
+  coin.scale = 0.4;
+
+  // Local ship: live input + physics (zero lag).
+  if (keyWentDown('up')) localShip.velocityY = -12;
+  localShip.velocityX = 0;
+  if (keyDown('left')) localShip.velocityX = -5;
+  if (keyDown('right')) localShip.velocityX = 5;
+  localShip.velocityY += 1.5;
+
+  // Remote ship: placed directly at its last received position (no local
+  // physics) so the host's collision checks see where it really is.
+  remoteShip.velocityX = 0;
+  remoteShip.velocityY = 0;
+  remoteShip.x = remoteX;
+  remoteShip.y = remoteY;
+
+  // Tell the other client where we are.
+  session?.send({ t: 'pos', x: Math.round(localShip.x), y: Math.round(localShip.y) });
+
+  drawSprite(backGround);
+  drawSpawnIndicator();
+  drawSprite(UFO1);
+  drawSprite(UFO2);
+  drawSprite(coin);
+  for (const b of blocks) drawSprite(b);
+
+  textAlign(LEFT, CENTER);
+  textSize(20);
+  fill('red');
+  text(`Health: ${health}`, 300, 20);
+  fill('green');
+  text(`Points: ${points}`, 300, 50);
+
+  // Deterministic enemy spawning + cleanup — identical on both via the seed.
+  count++;
+  if (count === 100 - difficulty * 25) {
+    spawnBlock();
+    count = 0;
+  }
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i];
+    if (b && (b.x < -10 || b.x > 410 || b.y < -10 || b.y > 410)) {
+      b.destroy();
+      blocks.splice(i, 1);
+    }
+  }
+
+  if (isHost) hostAuthoritativeEvents(localShip, remoteShip);
+}
+
+// Host only: the events that depend on BOTH ships and so can't be derived
+// independently. Coin pickups and damage are detected here and broadcast.
+function hostAuthoritativeEvents(localShip: Sprite, remoteShip: Sprite): void {
+  if (damageCooldown > 0) damageCooldown--;
+
+  if (coinExists && (localShip.isTouching(coin) || remoteShip.isTouching(coin))) {
+    points++;
+    placeCoin();
+    session?.send({ t: 'coin', x: Math.round(coin.x), y: Math.round(coin.y), points });
+  }
+
+  if (damageCooldown === 0) {
+    let damaged = offField(localShip) || offField(remoteShip);
+    if (!damaged) {
+      for (const b of blocks) {
+        if (b && (localShip.isTouching(b) || remoteShip.isTouching(b))) {
+          damaged = true;
+          break;
+        }
+      }
+    }
+    if (damaged) {
+      health--;
+      for (const b of blocks) b.destroy();
+      blocks = [];
+      respawnOwnShip();
+      damageCooldown = 15; // ~0.5 s; covers the remote ship's respawn round-trip
+      session?.send({ t: 'damage', health });
+    }
+  }
+}
+
+function drawOnlineMenus(): void {
+  if (health === 0) {
+    drawGameOver();
+    if (keyWentDown('r')) hostRestartToSelect();
+  } else if (points >= winCon) {
+    drawWinOnline();
+    if (keyWentDown('C')) hostContinue();
+  } else {
+    // difficulty === -1: host picks, which flips into gameplay next tick.
+    drawDifficultySelect();
+  }
+}
+
+function drawWinOnline(): void {
+  fill('green');
+  textSize(70);
+  textAlign(CENTER, CENTER);
+  text('You Win!', 200, 150);
+  fill('white');
+  textSize(20);
+  text(`Final Health: ${health}`, 200, 250);
+  text('press C to keep going!', 200, 275);
+}
+
+function hostRestartToSelect(): void {
+  health = 10;
+  points = 0;
+  winCon = 25;
+  count = 0;
+  nextSpawn = null;
+  for (const b of blocks) b.destroy();
+  blocks = [];
+  onlineMatchStarted = false;
+  difficulty = -1;
+  session?.send({ t: 'wait' });
+}
+
+function hostContinue(): void {
+  winCon += 25;
+  startMatchHost(false); // keep score/health, reseed a fresh wave, resume
 }
 
 function copyLink(link: string): void {
@@ -795,113 +995,35 @@ function drawCenterMessage(message: string, sub?: string): void {
 }
 
 function drawGuest(): void {
-  // Send our held controls upstream every tick; the host derives jump edges.
-  guest?.sendInput({ up: keyDown('up'), left: keyDown('left'), right: keyDown('right') });
-
   if (netStatus === 'disconnected') {
     drawCenterMessage('Disconnected from host.', 'Press R to leave');
     if (keyWentDown('r')) resetToLocalTitle();
     return;
   }
-
-  const snap = latestSnapshot;
-  if (!snap) {
-    drawCenterMessage('Connecting to host…', `Room ${roomCode}`);
+  if (!gameStarted) {
+    const msg = netStatus === 'connected' ? 'Waiting for host to start…' : 'Connecting to host…';
+    drawCenterMessage(msg, `Room ${roomCode}`);
     return;
   }
-  renderSnapshot(snap);
+  if (health <= 0) {
+    drawGuestOverlay('Game Over!', 'red', `Score: ${points}`);
+    return;
+  }
+  if (points >= winCon) {
+    drawGuestOverlay('You Win!', 'green', `Final Health: ${health}`);
+    return;
+  }
+  drawGameplayOnline();
 }
 
-function renderSnapshot(s: Snapshot): void {
-  if (s.phase === 'play') {
-    renderSnapshotPlay(s);
-    return;
-  }
-  if (s.phase === 'over') {
-    background('black');
-    fill('red');
-    textSize(70);
-    textAlign(CENTER, CENTER);
-    text('Game Over!', 200, 150);
-    fill('white');
-    textSize(20);
-    text(`Score: ${s.points}`, 200, 250);
-    text('Waiting for host…', 200, 300);
-    return;
-  }
-  if (s.phase === 'win') {
-    background('black');
-    fill('green');
-    textSize(70);
-    textAlign(CENTER, CENTER);
-    text('You Win!', 200, 150);
-    fill('white');
-    textSize(20);
-    text(`Final Health: ${s.health}`, 200, 250);
-    text('Waiting for host…', 200, 300);
-    return;
-  }
-  drawCenterMessage('Waiting for host to start…', `Room ${roomCode}`);
-}
-
-function renderSnapshotPlay(s: Snapshot): void {
-  // Mirror the host state the shared spawn indicator + HUD read from.
-  count = s.count;
-  difficulty = s.difficulty;
-  nextSpawn = s.spawn ? { direction: s.spawn.dir, x: s.spawn.x, y: s.spawn.y } : null;
-
-  backGround.setAnimation('space_1');
-  UFO1.setAnimation('ufo_1');
-  UFO1.x = s.ufo1.x;
-  UFO1.y = s.ufo1.y;
-  UFO2.setAnimation('ufo_2');
-  UFO2.x = s.ufo2.x;
-  UFO2.y = s.ufo2.y;
-
-  coin.setAnimation('coin');
-  coin.scale = 0.4;
-  coin.x = s.coin.x;
-  coin.y = s.coin.y;
-
-  syncGuestBlocks(s.blocks);
-
-  drawSprite(backGround);
-  drawSpawnIndicator();
-  drawSprite(UFO1);
-  drawSprite(UFO2);
-  drawSprite(coin);
-  for (const b of guestBlocks) drawSprite(b);
-
-  textAlign(LEFT, CENTER);
+function drawGuestOverlay(title: string, color: string, sub: string): void {
+  background('black');
+  fill(color);
+  textSize(70);
+  textAlign(CENTER, CENTER);
+  text(title, 200, 150);
+  fill('white');
   textSize(20);
-  fill('red');
-  text(`Health: ${s.health}`, 300, 20);
-  fill('green');
-  text(`Points: ${s.points}`, 300, 50);
-}
-
-// Reconcile the guest's block sprite pool to the snapshot. The pool only grows;
-// surplus sprites are parked off-screen rather than destroyed, because the guest
-// never calls drawSprites() (which is what reaps destroyed sprites), so churning
-// destroy()/createSprite() here would leak into the global registry.
-function syncGuestBlocks(snapBlocks: BlockSnap[]): void {
-  while (guestBlocks.length < snapBlocks.length) {
-    const sprite = createSprite(0, 0);
-    sprite.scale = 0.2;
-    guestBlocks.push(sprite);
-  }
-  for (let i = 0; i < guestBlocks.length; i++) {
-    const sprite = guestBlocks[i];
-    if (!sprite) continue;
-    const snap = i < snapBlocks.length ? snapBlocks[i] : undefined;
-    if (!snap) {
-      sprite.x = -9999;
-      sprite.y = -9999;
-      continue;
-    }
-    sprite.x = snap.x;
-    sprite.y = snap.y;
-    const name = shipAnimations[snap.anim];
-    if (name) sprite.setAnimation(name);
-  }
+  text(sub, 200, 250);
+  text('Waiting for host…', 200, 300);
 }

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -1,22 +1,16 @@
 // Public barrel for the online co-op layer. game.ts imports only from here.
 
-export type {
-  BlockSnap,
-  NetMessage,
-  Phase,
-  PlayerInput,
-  Snapshot,
-  SpawnSnap,
-} from './protocol';
-export { decode, encodeInput, encodeSnapshot } from './protocol';
 export {
-  type GuestHandlers,
-  type GuestSession,
-  type HostHandlers,
-  type HostSession,
-  hostSession,
-  joinSession,
-} from './session';
+  type CoinMsg,
+  type DamageMsg,
+  decode,
+  encode,
+  type NetMessage,
+  type PosMsg,
+  type StartMsg,
+  type WaitMsg,
+} from './protocol';
+export { hostSession, joinSession, type Session, type SessionHandlers } from './session';
 
 // Room-code alphabet: omits I/O/0/1/L so a shared code can't be misread.
 const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';

--- a/src/net/protocol.ts
+++ b/src/net/protocol.ts
@@ -1,92 +1,107 @@
-// Wire protocol for online co-op.
+// Wire protocol for online co-op (deterministic / event-driven).
 //
-// The host is authoritative: the guest sends its held controls (PlayerInput)
-// and the host broadcasts the full render state (Snapshot) every tick. v1
-// encodes as JSON — the payloads are tiny (two ships, a coin, a handful of
-// blocks) so at 30 Hz this is only a few KB/s. encode/decode are the ONLY
-// place that knows the wire format, so swapping to a packed binary layout
-// later changes nothing else.
+// Both clients run the SAME simulation: enemies are generated locally from a
+// shared seed (so they never travel over the wire), and each player runs their
+// OWN ship from local input — zero input lag, symmetrically. Only two kinds of
+// data cross the wire:
+//   1. each player's position (`pos`), so the other ship can be drawn; and
+//   2. the handful of host-authoritative events that touch shared state and the
+//      RNG — match (re)starts, coin pickups, damage, and the guest-wait signal —
+//      because those depend on BOTH ships and so can't be derived independently.
 //
-// decode() is defensive: a DataChannel is peer-to-peer but still untrusted, so
-// every field is validated and any malformed frame returns null rather than
-// throwing into the render loop.
+// decode() is defensive: every field is validated and a malformed frame returns
+// null rather than throwing into the render loop.
 
-// A player's controls for one tick — all HELD states, no edge flags. Sending
-// held state over an unreliable channel is robust: a dropped or reordered
-// packet costs at most one tick of latency, and the host derives the jump edge
-// itself from the rising edge of `up`. Latest-wins.
-export interface PlayerInput {
-  up: boolean;
-  left: boolean;
-  right: boolean;
-}
-
-// One enemy block as the guest needs to draw it. Direction/velocity live only
-// on the host; the guest just paints the sprite at (x,y) with animation index
-// `anim` (0..20 into the 21 retroship animations).
-export interface BlockSnap {
-  x: number;
-  y: number;
-  anim: number;
-}
-
-// Which screen the guest should render. The guest runs no simulation, so the
-// host tells it whether it's in gameplay or on a win/lose/waiting overlay.
-export type Phase = 'play' | 'win' | 'over' | 'wait';
-
-export interface SpawnSnap {
-  dir: 1 | 2 | 3 | 4;
-  x: number;
-  y: number;
-}
-
-export interface Snapshot {
-  phase: Phase;
-  ufo1: { x: number; y: number };
-  ufo2: { x: number; y: number };
-  coin: { x: number; y: number; shown: boolean };
-  blocks: BlockSnap[];
+// Host → guest. Begins (or, on a win-continue, re-syncs) a match: both sides
+// seed their RNG identically and reset to the same starting state.
+export interface StartMsg {
+  t: 'start';
+  seed: number;
+  difficulty: number;
   health: number;
   points: number;
   winCon: number;
-  difficulty: number;
-  count: number;
-  spawn: SpawnSnap | null;
+  coinX: number;
+  coinY: number;
 }
 
-export type NetMessage = { t: 'input'; i: PlayerInput } | { t: 'snap'; s: Snapshot };
-
-// Defensive upper bound on block count so a malformed frame can't make the
-// guest allocate unboundedly. Real gameplay never approaches this.
-const MAX_BLOCKS = 256;
-
-export function encodeInput(i: PlayerInput): string {
-  const msg: NetMessage = { t: 'input', i };
-  return JSON.stringify(msg);
+// Either direction, every tick: the sender's own ship position.
+export interface PosMsg {
+  t: 'pos';
+  x: number;
+  y: number;
 }
 
-export function encodeSnapshot(s: Snapshot): string {
-  const msg: NetMessage = { t: 'snap', s };
+// Host → guest: a coin was collected (by either ship). Carries the new score
+// and the next coin position (coins are host-authoritative, not seeded, because
+// who grabs one depends on both ships).
+export interface CoinMsg {
+  t: 'coin';
+  x: number;
+  y: number;
+  points: number;
+}
+
+// Host → guest: damage was taken (by either ship). Both clear the field and
+// respawn their own ship; health is authoritative.
+export interface DamageMsg {
+  t: 'damage';
+  health: number;
+}
+
+// Host → guest: the host left gameplay (restart to difficulty select). The
+// guest shows "waiting for host" until the next start.
+export interface WaitMsg {
+  t: 'wait';
+}
+
+export type NetMessage = StartMsg | PosMsg | CoinMsg | DamageMsg | WaitMsg;
+
+export function encode(msg: NetMessage): string {
   return JSON.stringify(msg);
 }
 
 export function decode(raw: string): NetMessage | null {
-  let parsed: unknown;
+  let v: unknown;
   try {
-    parsed = JSON.parse(raw);
+    v = JSON.parse(raw);
   } catch {
     return null;
   }
-  if (!isRecord(parsed)) return null;
-  if (parsed.t === 'input') {
-    const i = parseInput(parsed.i);
-    return i ? { t: 'input', i } : null;
+  if (!isRecord(v)) return null;
+  switch (v.t) {
+    case 'start':
+      return num(v.seed) &&
+        num(v.difficulty) &&
+        num(v.health) &&
+        num(v.points) &&
+        num(v.winCon) &&
+        num(v.coinX) &&
+        num(v.coinY)
+        ? {
+            t: 'start',
+            seed: v.seed,
+            difficulty: v.difficulty,
+            health: v.health,
+            points: v.points,
+            winCon: v.winCon,
+            coinX: v.coinX,
+            coinY: v.coinY,
+          }
+        : null;
+    case 'pos':
+      return num(v.x) && num(v.y) ? { t: 'pos', x: v.x, y: v.y } : null;
+    case 'coin':
+      return num(v.x) && num(v.y) && num(v.points)
+        ? { t: 'coin', x: v.x, y: v.y, points: v.points }
+        : null;
+    case 'damage':
+      return num(v.health) ? { t: 'damage', health: v.health } : null;
+    case 'wait':
+      return { t: 'wait' };
+    default:
+      return null;
   }
-  if (parsed.t === 'snap') {
-    const s = parseSnapshot(parsed.s);
-    return s ? { t: 'snap', s } : null;
-  }
-  return null;
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -95,72 +110,4 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 function num(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v);
-}
-
-function bool(v: unknown): v is boolean {
-  return typeof v === 'boolean';
-}
-
-function parseInput(v: unknown): PlayerInput | null {
-  if (!isRecord(v) || !bool(v.up) || !bool(v.left) || !bool(v.right)) return null;
-  return { up: v.up, left: v.left, right: v.right };
-}
-
-function parseXY(v: unknown): { x: number; y: number } | null {
-  if (!isRecord(v) || !num(v.x) || !num(v.y)) return null;
-  return { x: v.x, y: v.y };
-}
-
-function parseSpawn(v: unknown): SpawnSnap | null {
-  if (!isRecord(v)) return null;
-  const dir = v.dir;
-  if (dir !== 1 && dir !== 2 && dir !== 3 && dir !== 4) return null;
-  if (!num(v.x) || !num(v.y)) return null;
-  return { dir, x: v.x, y: v.y };
-}
-
-function parseSnapshot(v: unknown): Snapshot | null {
-  if (!isRecord(v)) return null;
-
-  const phase = v.phase;
-  if (phase !== 'play' && phase !== 'win' && phase !== 'over' && phase !== 'wait') return null;
-
-  const ufo1 = parseXY(v.ufo1);
-  const ufo2 = parseXY(v.ufo2);
-  if (!ufo1 || !ufo2) return null;
-
-  if (!isRecord(v.coin) || !num(v.coin.x) || !num(v.coin.y) || !bool(v.coin.shown)) return null;
-
-  if (!Array.isArray(v.blocks) || v.blocks.length > MAX_BLOCKS) return null;
-  const blocks: BlockSnap[] = [];
-  for (const b of v.blocks) {
-    if (!isRecord(b) || !num(b.x) || !num(b.y) || !num(b.anim)) return null;
-    blocks.push({ x: b.x, y: b.y, anim: b.anim });
-  }
-
-  if (!num(v.health) || !num(v.points) || !num(v.winCon) || !num(v.difficulty) || !num(v.count)) {
-    return null;
-  }
-
-  // spawn is legitimately null between cadence windows; only a non-null,
-  // malformed spawn is a decode failure.
-  let spawn: SpawnSnap | null = null;
-  if (v.spawn !== null) {
-    spawn = parseSpawn(v.spawn);
-    if (!spawn) return null;
-  }
-
-  return {
-    phase,
-    ufo1,
-    ufo2,
-    coin: { x: v.coin.x, y: v.coin.y, shown: v.coin.shown },
-    blocks,
-    health: v.health,
-    points: v.points,
-    winCon: v.winCon,
-    difficulty: v.difficulty,
-    count: v.count,
-    spawn,
-  };
 }

--- a/src/net/session.ts
+++ b/src/net/session.ts
@@ -1,14 +1,13 @@
-// WebRTC session orchestration. The host opens the DataChannel and drives the
-// offer; the guest answers. Trickle-ICE candidates flow both ways over the
-// signaling WebSocket until the channel opens, after which input/snapshot
-// traffic is peer-to-peer.
+// WebRTC session orchestration. Symmetric: both roles expose the same
+// send()/onMessage surface — the only asymmetry is that the host creates the
+// offer and the guest answers. Trickle-ICE flows over the signaling WebSocket
+// until the DataChannel opens, after which all game traffic is peer-to-peer.
 //
-// This module is the one piece that can't be unit-tested headlessly (no
-// RTCPeerConnection outside a browser), so it stays deliberately thin: parsing
-// and validation live in protocol.ts / signaling.ts, and this file is just the
-// state-machine wiring.
+// Deliberately thin: parsing/validation live in protocol.ts and signaling.ts;
+// this is just the state-machine wiring (and the one piece that can't be tested
+// headlessly, since there's no RTCPeerConnection outside a browser).
 
-import { decode, encodeInput, encodeSnapshot, type PlayerInput, type Snapshot } from './protocol';
+import { decode, encode, type NetMessage } from './protocol';
 import { connectSignaling, type SignalChannel, type SignalMessage } from './signaling';
 
 // Public STUN only — per the project assumption that ICE is viable. No TURN, so
@@ -17,149 +16,31 @@ import { connectSignaling, type SignalChannel, type SignalMessage } from './sign
 const ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
 const CHANNEL_LABEL = 'game';
 // Unreliable + unordered: gameplay is latest-wins, so never retransmit a stale
-// input or snapshot — just wait for the next one.
+// position or event — just wait for the next one.
 const CHANNEL_INIT: RTCDataChannelInit = { ordered: false, maxRetransmits: 0 };
 
-export interface HostSession {
-  sendSnapshot(s: Snapshot): void;
+export interface Session {
+  send(msg: NetMessage): void;
   close(): void;
 }
 
-export interface GuestSession {
-  sendInput(i: PlayerInput): void;
-  close(): void;
-}
-
-export interface HostHandlers {
-  onPeerInput(i: PlayerInput): void;
+export interface SessionHandlers {
+  onMessage(msg: NetMessage): void;
   onConnected(): void;
   onDisconnected(): void;
 }
 
-export interface GuestHandlers {
-  onSnapshot(s: Snapshot): void;
-  onConnected(): void;
-  onDisconnected(): void;
+export function hostSession(code: string, h: SessionHandlers): Session {
+  return createSession(code, 'host', h);
 }
 
-// Buffers ICE candidates that arrive before the remote description is set, then
-// flushes them once it is. addIceCandidate before setRemoteDescription throws.
-interface IceQueue {
-  remoteSet: boolean;
-  pending: RTCIceCandidateInit[];
+export function joinSession(code: string, h: SessionHandlers): Session {
+  return createSession(code, 'guest', h);
 }
 
-async function acceptIce(
-  pc: RTCPeerConnection,
-  q: IceQueue,
-  c: RTCIceCandidateInit,
-): Promise<void> {
-  if (q.remoteSet) await pc.addIceCandidate(c);
-  else q.pending.push(c);
-}
-
-async function flushIce(pc: RTCPeerConnection, q: IceQueue): Promise<void> {
-  q.remoteSet = true;
-  for (const c of q.pending) await pc.addIceCandidate(c);
-  q.pending.length = 0;
-}
-
-function wireChannel(
-  channel: RTCDataChannel,
-  onData: (raw: string) => void,
-  onOpen: () => void,
-  onClose: () => void,
-): void {
-  channel.onopen = (): void => onOpen();
-  channel.onclose = (): void => onClose();
-  channel.onmessage = (ev: MessageEvent): void => {
-    if (typeof ev.data === 'string') onData(ev.data);
-  };
-}
-
-function safeClose(
-  channel: RTCDataChannel | null,
-  pc: RTCPeerConnection,
-  signal: SignalChannel,
-): void {
-  try {
-    channel?.close();
-  } catch {
-    /* already closing */
-  }
-  try {
-    pc.close();
-  } catch {
-    /* already closing */
-  }
-  signal.close();
-}
-
-export function hostSession(code: string, h: HostHandlers): HostSession {
+function createSession(code: string, role: 'host' | 'guest', h: SessionHandlers): Session {
   const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
-  const channel = pc.createDataChannel(CHANNEL_LABEL, CHANNEL_INIT);
-  const ice: IceQueue = { remoteSet: false, pending: [] };
-  let closed = false;
-
-  const disconnect = (): void => {
-    if (!closed) {
-      closed = true;
-      h.onDisconnected();
-    }
-  };
-
-  // signal is created first so the handlers below can reference it; onSignal is
-  // a hoisted function declaration so onMessage can name it before its body.
-  const signal: SignalChannel = connectSignaling(code, 'host', {
-    onMessage: (m) => void onSignal(m),
-    onClose: () => {},
-    onError: () => {},
-  });
-
-  wireChannel(
-    channel,
-    (raw) => {
-      const msg = decode(raw);
-      if (msg?.t === 'input') h.onPeerInput(msg.i);
-    },
-    h.onConnected,
-    disconnect,
-  );
-
-  pc.onicecandidate = (ev): void => {
-    if (ev.candidate) signal.send({ type: 'ice', candidate: ev.candidate.toJSON() });
-  };
-  pc.onconnectionstatechange = (): void => {
-    if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') disconnect();
-  };
-
-  async function onSignal(m: SignalMessage): Promise<void> {
-    if (m.type === 'peer-joined') {
-      const offer = await pc.createOffer();
-      await pc.setLocalDescription(offer);
-      signal.send({ type: 'offer', sdp: offer.sdp ?? '' });
-    } else if (m.type === 'answer') {
-      await pc.setRemoteDescription({ type: 'answer', sdp: m.sdp });
-      await flushIce(pc, ice);
-    } else if (m.type === 'ice') {
-      await acceptIce(pc, ice, m.candidate);
-    }
-  }
-
-  return {
-    sendSnapshot(s: Snapshot): void {
-      if (channel.readyState === 'open') channel.send(encodeSnapshot(s));
-    },
-    close(): void {
-      closed = true;
-      safeClose(channel, pc, signal);
-    },
-  };
-}
-
-export function joinSession(code: string, h: GuestHandlers): GuestSession {
-  const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
-  const ice: IceQueue = { remoteSet: false, pending: [] };
+  const ice = { remoteSet: false, pending: [] as RTCIceCandidateInit[] };
   let channel: RTCDataChannel | null = null;
   let closed = false;
 
@@ -170,24 +51,33 @@ export function joinSession(code: string, h: GuestHandlers): GuestSession {
     }
   };
 
-  const signal: SignalChannel = connectSignaling(code, 'guest', {
+  const wire = (ch: RTCDataChannel): void => {
+    channel = ch;
+    ch.onopen = (): void => h.onConnected();
+    ch.onclose = (): void => disconnect();
+    ch.onmessage = (ev: MessageEvent): void => {
+      if (typeof ev.data !== 'string') return;
+      const msg = decode(ev.data);
+      if (msg) h.onMessage(msg);
+    };
+  };
+
+  // The host opens the channel (and so the offer carries it); the guest receives
+  // it via ondatachannel.
+  if (role === 'host') {
+    wire(pc.createDataChannel(CHANNEL_LABEL, CHANNEL_INIT));
+  } else {
+    pc.ondatachannel = (ev): void => wire(ev.channel);
+  }
+
+  // signal is created before the handlers below reference it; onSignal is a
+  // hoisted function declaration so onMessage can name it before its body.
+  const signal: SignalChannel = connectSignaling(code, role, {
     onMessage: (m) => void onSignal(m),
     onClose: () => {},
     onError: () => {},
   });
 
-  pc.ondatachannel = (ev): void => {
-    channel = ev.channel;
-    wireChannel(
-      channel,
-      (raw) => {
-        const msg = decode(raw);
-        if (msg?.t === 'snap') h.onSnapshot(msg.s);
-      },
-      h.onConnected,
-      disconnect,
-    );
-  };
   pc.onicecandidate = (ev): void => {
     if (ev.candidate) signal.send({ type: 'ice', candidate: ev.candidate.toJSON() });
   };
@@ -196,24 +86,48 @@ export function joinSession(code: string, h: GuestHandlers): GuestSession {
   };
 
   async function onSignal(m: SignalMessage): Promise<void> {
-    if (m.type === 'offer') {
+    if (role === 'host' && m.type === 'peer-joined') {
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      signal.send({ type: 'offer', sdp: offer.sdp ?? '' });
+    } else if (role === 'guest' && m.type === 'offer') {
       await pc.setRemoteDescription({ type: 'offer', sdp: m.sdp });
-      await flushIce(pc, ice);
+      await flushIce();
       const answer = await pc.createAnswer();
       await pc.setLocalDescription(answer);
       signal.send({ type: 'answer', sdp: answer.sdp ?? '' });
+    } else if (role === 'host' && m.type === 'answer') {
+      await pc.setRemoteDescription({ type: 'answer', sdp: m.sdp });
+      await flushIce();
     } else if (m.type === 'ice') {
-      await acceptIce(pc, ice, m.candidate);
+      if (ice.remoteSet) await pc.addIceCandidate(m.candidate);
+      else ice.pending.push(m.candidate);
     }
   }
 
+  async function flushIce(): Promise<void> {
+    ice.remoteSet = true;
+    for (const c of ice.pending) await pc.addIceCandidate(c);
+    ice.pending.length = 0;
+  }
+
   return {
-    sendInput(i: PlayerInput): void {
-      if (channel?.readyState === 'open') channel.send(encodeInput(i));
+    send(msg: NetMessage): void {
+      if (channel?.readyState === 'open') channel.send(encode(msg));
     },
     close(): void {
       closed = true;
-      safeClose(channel, pc, signal);
+      try {
+        channel?.close();
+      } catch {
+        /* already closing */
+      }
+      try {
+        pc.close();
+      } catch {
+        /* already closing */
+      }
+      signal.close();
     },
   };
 }

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1,107 +1,81 @@
 import { describe, expect, it } from 'vitest';
-import { decode, encodeInput, encodeSnapshot, type PlayerInput, type Snapshot } from '../src/net';
+import { randomNumber, setRandomSeed } from '../src/gamelab';
+import { decode, encode, type NetMessage } from '../src/net';
 
-const sampleInput: PlayerInput = { up: true, left: false, right: true };
+const samples: NetMessage[] = [
+  {
+    t: 'start',
+    seed: 12345,
+    difficulty: 2,
+    health: 10,
+    points: 0,
+    winCon: 25,
+    coinX: 120,
+    coinY: 300,
+  },
+  { t: 'pos', x: 150, y: 275 },
+  { t: 'coin', x: 80, y: 90, points: 7 },
+  { t: 'damage', health: 4 },
+  { t: 'wait' },
+];
 
-const sampleSnapshot: Snapshot = {
-  phase: 'play',
-  ufo1: { x: 100, y: 200 },
-  ufo2: { x: 250, y: 80 },
-  coin: { x: 150, y: 150, shown: true },
-  blocks: [
-    { x: 410, y: 120, anim: 3 },
-    { x: -10, y: 300, anim: 17 },
-  ],
-  health: 9,
-  points: 4,
-  winCon: 25,
-  difficulty: 2,
-  count: 31,
-  spawn: { dir: 1, x: 410, y: 120 },
-};
-
-describe('protocol: input round-trip', () => {
-  it('encodes and decodes a PlayerInput losslessly', () => {
-    const decoded = decode(encodeInput(sampleInput));
-    expect(decoded).toEqual({ t: 'input', i: sampleInput });
-  });
-
-  it('preserves every button combination', () => {
-    for (let bits = 0; bits < 8; bits++) {
-      const input: PlayerInput = {
-        up: Boolean(bits & 1),
-        left: Boolean(bits & 2),
-        right: Boolean(bits & 4),
-      };
-      expect(decode(encodeInput(input))).toEqual({ t: 'input', i: input });
+describe('protocol: round-trip', () => {
+  it('encodes and decodes every message type losslessly', () => {
+    for (const msg of samples) {
+      expect(decode(encode(msg))).toEqual(msg);
     }
   });
 });
 
-describe('protocol: snapshot round-trip', () => {
-  it('encodes and decodes a full Snapshot losslessly', () => {
-    const decoded = decode(encodeSnapshot(sampleSnapshot));
-    expect(decoded).toEqual({ t: 'snap', s: sampleSnapshot });
-  });
-
-  it('carries a null spawn (the between-cadence state)', () => {
-    const snap: Snapshot = { ...sampleSnapshot, spawn: null, blocks: [] };
-    const decoded = decode(encodeSnapshot(snap));
-    expect(decoded).toEqual({ t: 'snap', s: snap });
-  });
-
-  it('round-trips each phase value', () => {
-    for (const phase of ['play', 'win', 'over', 'wait'] as const) {
-      const snap: Snapshot = { ...sampleSnapshot, phase };
-      const decoded = decode(encodeSnapshot(snap));
-      expect(decoded?.t === 'snap' && decoded.s.phase).toBe(phase);
-    }
-  });
-});
-
-describe('protocol: decode rejects malformed input', () => {
-  it('returns null on non-JSON', () => {
+describe('protocol: decode rejects malformed frames', () => {
+  it('returns null on non-JSON or a primitive', () => {
     expect(decode('not json{')).toBeNull();
     expect(decode('')).toBeNull();
-  });
-
-  it('returns null on a JSON primitive or unknown tag', () => {
     expect(decode('42')).toBeNull();
     expect(decode('null')).toBeNull();
+  });
+
+  it('returns null on an unknown tag', () => {
     expect(decode(JSON.stringify({ t: 'bogus' }))).toBeNull();
+    expect(decode(JSON.stringify({ t: 'snap' }))).toBeNull();
   });
 
-  it('returns null when input fields are the wrong type', () => {
+  it('returns null when a required field is missing or the wrong type', () => {
+    expect(decode(JSON.stringify({ t: 'pos', x: 1 }))).toBeNull();
+    expect(decode(JSON.stringify({ t: 'pos', x: '1', y: 2 }))).toBeNull();
+    expect(decode(JSON.stringify({ t: 'damage' }))).toBeNull();
+    expect(decode(JSON.stringify({ t: 'coin', x: 1, y: 2 }))).toBeNull();
     expect(
-      decode(JSON.stringify({ t: 'input', i: { up: 1, left: false, right: false } })),
+      decode(JSON.stringify({ t: 'start', seed: 1, difficulty: 1, health: 1, points: 1 })),
     ).toBeNull();
-    expect(decode(JSON.stringify({ t: 'input', i: { up: true } }))).toBeNull();
   });
 
-  it('returns null on an invalid phase', () => {
-    const bad = { ...sampleSnapshot, phase: 'paused' };
-    expect(decode(JSON.stringify({ t: 'snap', s: bad }))).toBeNull();
+  it('returns null on a non-finite number (NaN serializes to JSON null)', () => {
+    expect(decode(JSON.stringify({ t: 'pos', x: Number.NaN, y: 0 }))).toBeNull();
+  });
+});
+
+describe('determinism: a shared seed reproduces the same enemy stream', () => {
+  // Mirrors what spawnBlock/decideNextSpawn draw each spawn: direction, a wall
+  // coordinate, and a sprite index. Two clients seeded identically must produce
+  // identical sequences — that's what lets enemies be generated locally on both
+  // instead of streamed.
+  function spawnSequence(seed: number, draws: number): number[] {
+    setRandomSeed(seed);
+    const out: number[] = [];
+    for (let i = 0; i < draws; i++) {
+      out.push(randomNumber(1, 4)); // direction
+      out.push(randomNumber(10, 390)); // wall coordinate
+      out.push(randomNumber(0, 20)); // sprite index
+    }
+    return out;
+  }
+
+  it('produces identical sequences for the same seed', () => {
+    expect(spawnSequence(98765, 50)).toEqual(spawnSequence(98765, 50));
   });
 
-  it('returns null on an invalid spawn direction', () => {
-    const bad = { ...sampleSnapshot, spawn: { dir: 5, x: 0, y: 0 } };
-    expect(decode(JSON.stringify({ t: 'snap', s: bad }))).toBeNull();
-  });
-
-  it('returns null on a non-finite coordinate', () => {
-    const bad = { ...sampleSnapshot, ufo1: { x: Number.NaN, y: 0 } };
-    // NaN serializes to JSON null, which fails the numeric guard.
-    expect(decode(JSON.stringify({ t: 'snap', s: bad }))).toBeNull();
-  });
-
-  it('returns null when a block entry is malformed', () => {
-    const bad = { ...sampleSnapshot, blocks: [{ x: 1, y: 2 }] };
-    expect(decode(JSON.stringify({ t: 'snap', s: bad }))).toBeNull();
-  });
-
-  it('returns null when blocks exceeds the safety cap', () => {
-    const huge = Array.from({ length: 257 }, () => ({ x: 0, y: 0, anim: 0 }));
-    const bad = { ...sampleSnapshot, blocks: huge };
-    expect(decode(JSON.stringify({ t: 'snap', s: bad }))).toBeNull();
+  it('produces different sequences for different seeds', () => {
+    expect(spawnSequence(1, 50)).not.toEqual(spawnSequence(2, 50));
   });
 });


### PR DESCRIPTION
… lag)

v1 streamed a full host-authoritative snapshot every tick, so the guest had no local ship and felt the whole round-trip as input lag. v2: both clients run the SAME simulation. Enemies are generated locally from a host-chosen shared seed (never streamed); each player flies their OWN ship from local input, so neither player has input lag. Only positions + a few host-authoritative events cross the wire.

- protocol: replace Snapshot/PlayerInput with start/pos/coin/damage/wait events.
- session: symmetric send()/onMessage for both roles (only offer-vs-answer differs).
- game.ts: shared drawGameplayOnline (local ship vs remote-pos ship); seeded enemies via setRandomSeed; host-authoritative coin/damage in hostAuthoritativeEvents; deletes the snapshot render path. Local play reverted to its original WASD-UFO2 form.
- coins use Math.random (host-sent), not the seeded stream, so the enemy RNG stays byte-identical across clients. damageCooldown debounces off-field damage for the networked remote ship (~1/2 RTT respawn gap).
- tests: protocol round-trip/reject + a determinism test (same seed -> same RNG sequence). Known limit: enemy sync assumes both tabs stay foregrounded; host-authoritative damage keeps any drift cosmetic.

Live two-machine WebRTC + gameplay sync still needs a manual check.