### PR TITLE
add online co-op desync diagnostics (?debug=1)

### DIFF
--- a/src/diag.ts
+++ b/src/diag.ts
@@ -1,0 +1,60 @@
+// Debug-only on-screen diagnostics for online co-op, enabled with ?debug=1.
+//
+// The host renders a running log strip under the canvas, comparing its own sim
+// state against the guest's (piped over the data channel as `diag` frames), so
+// a seed/coin desync is visible on ONE screen instead of diffing two browser
+// consoles. Off by default and entirely separate from the game canvas — when
+// ?debug=1 is absent, nothing here ever runs.
+
+let enabled: boolean | null = null;
+
+// Read once: whether ?debug=1 is on the current URL. Only the host needs it —
+// the guest emits its digest unconditionally (a few bytes every ~0.5 s).
+export function debugEnabled(): boolean {
+  if (enabled === null) {
+    enabled = new URLSearchParams(location.search).get('debug') === '1';
+  }
+  return enabled;
+}
+
+let panel: HTMLElement | null = null;
+const MAX_LINES = 200;
+
+function ensurePanel(): HTMLElement {
+  if (panel) return panel;
+  const el = document.createElement('div');
+  el.id = 'diag';
+  // Fixed bottom strip so it sits clear of the centered canvas regardless of
+  // the page's flex layout. CSP allows inline styles (style-src 'unsafe-inline').
+  el.style.cssText = [
+    'position:fixed',
+    'left:0',
+    'right:0',
+    'bottom:0',
+    'max-height:32vh',
+    'overflow-y:auto',
+    'margin:0',
+    'padding:4px 8px',
+    'background:rgba(0,0,0,0.85)',
+    'font:11px/1.35 ui-monospace,Menlo,Consolas,monospace',
+    'white-space:pre',
+    'z-index:9999',
+    'border-top:1px solid #333',
+  ].join(';');
+  document.body.appendChild(el);
+  panel = el;
+  return el;
+}
+
+// Append one line to the log. ok === false → red (mismatch), true → green
+// (match), undefined → grey (informational). Oldest lines are trimmed and the
+// strip auto-scrolls to the newest.
+export function diagLine(text: string, ok?: boolean): void {
+  const el = ensurePanel();
+  const line = document.createElement('div');
+  line.textContent = text;
+  line.style.color = ok === false ? '#f77' : ok === true ? '#9f9' : '#bbb';
+  el.appendChild(line);
+  while (el.childElementCount > MAX_LINES) el.firstElementChild?.remove();
+  el.scrollTop = el.scrollHeight;
+}

--- a/src/game.ts
+++ b/src/game.ts
@@ -9,6 +9,7 @@
 // Do not "fix" any of them until the port is signed off as visually identical
 // to the code.org page; then queue them as labeled follow-ups.
 
+import { debugEnabled, diagLine } from './diag';
 import {
   background,
   CENTER,
@@ -34,6 +35,7 @@ import {
   textSize,
 } from './gamelab';
 import {
+  type DiagMsg,
   hostSession,
   joinSession,
   makeRoomCode,
@@ -85,6 +87,24 @@ let gameStarted = false;
 // ticks (the host can't force the remote ship back on-field; the guest's own
 // respawn position only arrives ~½ RTT later).
 let damageCooldown = 0;
+
+// Debug diagnostics (online; ?debug=1 on the host). A monotonic per-match frame
+// counter plus the most-recent spawn signature, reset at every (re)start. The
+// guest pipes these to the host; the host also keeps its own spawn signatures by
+// ordinal (hostSpawns) to compare against. See src/diag.ts.
+let netTick = 0;
+let spawnCount = 0;
+let lastSpawnN = -1;
+let lastSpawnDir = 0;
+let lastSpawnSprite = 0;
+const hostSpawns: Array<{ dir: number; sprite: number }> = [];
+
+function resetDiag(): void {
+  netTick = 0;
+  spawnCount = 0;
+  lastSpawnN = -1;
+  hostSpawns.length = 0;
+}
 
 const shipAnimations: string[] = [];
 for (let i = 1; i <= 21; i++) {
@@ -304,6 +324,16 @@ function spawnBlock(): void {
   const name = shipAnimations[randomIndex];
   if (name) newBlock.setAnimation(name);
   blocks.push(newBlock);
+
+  // Record this enemy's seed-derived signature for the online desync log. Both
+  // clients run spawnBlock; only the host reads hostSpawns (keyed by ordinal).
+  if (netRole !== 'local') {
+    spawnCount++;
+    lastSpawnN = spawnCount;
+    lastSpawnDir = target.direction;
+    lastSpawnSprite = randomIndex;
+    hostSpawns[spawnCount] = { dir: target.direction, sprite: randomIndex };
+  }
 
   decideNextSpawn();
 }
@@ -657,6 +687,7 @@ function resetToLocalTitle(): void {
   onlineMatchStarted = false;
   gameStarted = false;
   damageCooldown = 0;
+  resetDiag();
   for (const b of blocks) b.destroy();
   blocks = [];
   players = 1;
@@ -713,6 +744,7 @@ function onNetMessage(msg: NetMessage): void {
       count = 0;
       nextSpawn = null;
       damageCooldown = 0;
+      resetDiag();
       for (const b of blocks) b.destroy();
       blocks = [];
       coin.x = msg.coinX;
@@ -735,7 +767,43 @@ function onNetMessage(msg: NetMessage): void {
     case 'wait':
       gameStarted = false;
       break;
+    case 'diag':
+      if (netRole === 'host' && debugEnabled()) showDiag(msg);
+      break;
   }
+}
+
+// Host-only: render one comparison line for an incoming guest digest. The guest
+// frame is ~½ RTT old, so Δtick folds in latency; the spawn-signature check is
+// latency-independent (keyed by ordinal) and is the real seed-sync test. A red
+// line means a genuine divergence (enemy stream or coin), grey means we can't
+// compare yet (host hasn't reached that spawn ordinal).
+function showDiag(g: DiagMsg): void {
+  let seq: string;
+  let ok: boolean | undefined;
+  if (g.sigN < 0) {
+    seq = 'seq —';
+  } else {
+    const own = hostSpawns[g.sigN];
+    if (!own) {
+      seq = `seq#${g.sigN} host-behind`;
+    } else {
+      ok = own.dir === g.sigDir && own.sprite === g.sigSprite;
+      seq = ok
+        ? `seq#${g.sigN}✓`
+        : `seq#${g.sigN}✗ G(d${g.sigDir},s${g.sigSprite}) H(d${own.dir},s${own.sprite})`;
+    }
+  }
+  const hx = Math.round(coin.x);
+  const hy = Math.round(coin.y);
+  const coinOk = Math.abs(hx - g.coinX) <= 2 && Math.abs(hy - g.coinY) <= 2;
+  const line =
+    `G t${g.tick} sp${g.spawns} coin(${g.coinX},${g.coinY}) p${g.points} h${g.health}` +
+    ` | H t${netTick} sp${spawnCount} coin(${hx},${hy}) p${points} h${health}` +
+    ` | ${seq} coin${coinOk ? '✓' : '✗'} Δt${netTick - g.tick}`;
+  // Red on any confirmed mismatch; otherwise green when both checks pass, grey
+  // when the seq check is still indeterminate.
+  diagLine(line, ok === false || !coinOk ? false : ok === true ? true : undefined);
 }
 
 // Host: seed and broadcast a (re)start. `fresh` resets score/health for a new
@@ -751,6 +819,7 @@ function startMatchHost(fresh: boolean): void {
   count = 0;
   nextSpawn = null;
   damageCooldown = 0;
+  resetDiag();
   for (const b of blocks) b.destroy();
   blocks = [];
   placeCoin();
@@ -792,6 +861,7 @@ function drawGameplayOnline(): void {
   const isHost = netRole === 'host';
   const localShip = isHost ? UFO1 : UFO2;
   const remoteShip = isHost ? UFO2 : UFO1;
+  netTick++;
 
   if (!nextSpawn) decideNextSpawn();
 
@@ -817,6 +887,23 @@ function drawGameplayOnline(): void {
 
   // Tell the other client where we are.
   session?.send({ t: 'pos', x: Math.round(localShip.x), y: Math.round(localShip.y) });
+
+  // Guest pipes a periodic digest back to the host for the desync log (~2/s).
+  // Sent unconditionally — the host decides whether to display it (?debug=1).
+  if (netRole === 'guest' && netTick % 15 === 0) {
+    session?.send({
+      t: 'diag',
+      tick: netTick,
+      spawns: spawnCount,
+      sigN: lastSpawnN,
+      sigDir: lastSpawnDir,
+      sigSprite: lastSpawnSprite,
+      coinX: Math.round(coin.x),
+      coinY: Math.round(coin.y),
+      points,
+      health,
+    });
+  }
 
   drawSprite(backGround);
   drawSpawnIndicator();

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -3,6 +3,7 @@
 export {
   type CoinMsg,
   type DamageMsg,
+  type DiagMsg,
   decode,
   encode,
   type NetMessage,

--- a/src/net/protocol.ts
+++ b/src/net/protocol.ts
@@ -55,7 +55,26 @@ export interface WaitMsg {
   t: 'wait';
 }
 
-export type NetMessage = StartMsg | PosMsg | CoinMsg | DamageMsg | WaitMsg;
+// Guest → host, debug only (?debug=1 on the host). A periodic digest of the
+// guest's sim state so the host can render a desync log on one screen instead of
+// diffing two browser consoles. `sigN`/`sigDir`/`sigSprite` are the guest's
+// most-recent spawn signature (ordinal + the two seeded draws that define the
+// enemy) — comparing them against the host's own record of spawn #sigN is the
+// latency-independent test of whether the shared seed actually stayed in sync.
+export interface DiagMsg {
+  t: 'diag';
+  tick: number; // sender's online-frame counter since match start
+  spawns: number; // total enemies spawned so far
+  sigN: number; // ordinal of the most recent spawn (-1 if none yet)
+  sigDir: number; // that spawn's direction draw
+  sigSprite: number; // that spawn's sprite-index draw
+  coinX: number;
+  coinY: number;
+  points: number;
+  health: number;
+}
+
+export type NetMessage = StartMsg | PosMsg | CoinMsg | DamageMsg | WaitMsg | DiagMsg;
 
 export function encode(msg: NetMessage): string {
   return JSON.stringify(msg);
@@ -99,6 +118,29 @@ export function decode(raw: string): NetMessage | null {
       return num(v.health) ? { t: 'damage', health: v.health } : null;
     case 'wait':
       return { t: 'wait' };
+    case 'diag':
+      return num(v.tick) &&
+        num(v.spawns) &&
+        num(v.sigN) &&
+        num(v.sigDir) &&
+        num(v.sigSprite) &&
+        num(v.coinX) &&
+        num(v.coinY) &&
+        num(v.points) &&
+        num(v.health)
+        ? {
+            t: 'diag',
+            tick: v.tick,
+            spawns: v.spawns,
+            sigN: v.sigN,
+            sigDir: v.sigDir,
+            sigSprite: v.sigSprite,
+            coinX: v.coinX,
+            coinY: v.coinY,
+            points: v.points,
+            health: v.health,
+          }
+        : null;
     default:
       return null;
   }

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -17,6 +17,18 @@ const samples: NetMessage[] = [
   { t: 'coin', x: 80, y: 90, points: 7 },
   { t: 'damage', health: 4 },
   { t: 'wait' },
+  {
+    t: 'diag',
+    tick: 90,
+    spawns: 6,
+    sigN: 6,
+    sigDir: 2,
+    sigSprite: 14,
+    coinX: 110,
+    coinY: 280,
+    points: 5,
+    health: 9,
+  },
 ];
 
 describe('protocol: round-trip', () => {
@@ -48,6 +60,7 @@ describe('protocol: decode rejects malformed frames', () => {
     expect(
       decode(JSON.stringify({ t: 'start', seed: 1, difficulty: 1, health: 1, points: 1 })),
     ).toBeNull();
+    expect(decode(JSON.stringify({ t: 'diag', tick: 1, spawns: 2 }))).toBeNull();
   });
 
   it('returns null on a non-finite number (NaN serializes to JSON null)', () => {


### PR DESCRIPTION
Guest pipes a periodic state digest (frame counter, spawn signature, coin position, score/health) to the host over the data channel. The host, when loaded with ?debug=1, renders a running comparison log in a fixed strip under the canvas: enemy-stream seed match (latency-independent, keyed by spawn ordinal), coin match, and tick drift. Lets a desync be diagnosed on one screen instead of diffing two browser consoles.

No behavior change when ?debug=1 is absent. New `diag` wire message is defensively decoded and round-trip tested.